### PR TITLE
Fix build: missing header

### DIFF
--- a/src/int512.h
+++ b/src/int512.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "array.h"
 #include "bitint_arithmetic.h"
+#include <tuple>
 #include <iomanip>
 #include <iostream>
 namespace bn256 {


### PR DESCRIPTION
Tuples are used in this file, but not included. Include header to successfully build.