### PR TITLE
add #include <cstdint>, needed for C++20 & gcc13

### DIFF
--- a/include/bn256/bn256.h
+++ b/include/bn256/bn256.h
@@ -23,6 +23,7 @@
 #include <system_error>
 #include <cstring>
 #include <functional>
+#include <cstdint>
 #include <bn256/span.h>
 
 namespace bn256 {


### PR DESCRIPTION
amazingly enough, I needed this additional include when building in C++20 with gcc13