### PR TITLE
don't use BitInt when UBSAN is enabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,12 @@
 include(CheckCXXSourceCompiles)
 
 check_cxx_source_compiles("
+#if defined(__has_feature)
+#  if __has_feature(undefined_behavior_sanitizer)
+#    error UBSAN and bitint don't work together yet, see https://github.com/llvm/llvm-project/issues/64100
+#  endif
+#endif
+
 int main() {
   using T=_ExtInt(512);
   return 0;


### PR DESCRIPTION
Unfortunately these aren't compatible with each other and causes internal UBSAN checks to fail so I think it's best to just disable BitInt in this use case for now; see linked issue in comment.