### PR TITLE
move to `macos-latest` for macos test to get CI working again

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,7 +23,7 @@ jobs:
           - name: MacOS
             mode: Release
             os: macos
-            vm_image: macos-11
+            vm_image: macos-latest
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:


### PR DESCRIPTION
`macos-11` has been gone for some time; move to `macos-latest` otherwise CI cannot complete