### PR TITLE
use compiler provided define to detect if BMI2 is compile-time enabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,6 @@ endif()
 
 if (BN256_ENABLE_BMI2)
         target_compile_options(bn256 PUBLIC -mbmi2)
-        target_compile_definitions(bn256 PRIVATE BN256_HAS_BMI2)
 endif()
 
 if(BN256_INSTALL_COMPONENT)

--- a/src/bitint_arithmetic.h
+++ b/src/bitint_arithmetic.h
@@ -49,7 +49,7 @@ constexpr bool addcarry_u64(bool carry, uint64_t a, uint64_t b, uint64_t* c) noe
 }
 
 constexpr uint64_t mulx_u64(uint64_t a, uint64_t b, uint64_t* hi) noexcept {
-#ifdef BN256_HAS_BMI2
+#ifdef __BMI2__
    if (!std::is_constant_evaluated()) {
       unsigned long long local_hi=0;
       auto r = _mulx_u64(a, b,&local_hi);


### PR DESCRIPTION
The problem with using this project local `BN256_HAS_BMI2` define to detect whether using BMI2 is enabled is that it means someone compiling the project (or e.g. spring) with for example `-march=x86-64-v3` or `-march=native` and is unaware of this cmake option then they won't get this usage of BMI2 even though BMI2 is enabled. We can use `__BMI2__` to detect if BMI2 is enabled at compile time.

Most of the speed up from enabling BMI2 is, from my memory, not this specific instance but rather the compiler being smart enough across the library as a whole. Still useful tweak though for now, until we can figure out a good way to dynamically use BMI2 at runtime.

Okay to be fair, I can't find `__BMI2__` authoritatively documented anywhere. Can see [it work empirically](https://godbolt.org/z/bxG9b3j8E), and [see in clang where it's added](https://github.com/llvm/llvm-project/blob/f01b56ffb3bee6606063ab4e6e8883eb2e4a48ea/clang/lib/Basic/Targets/X86.cpp#L820), and do a code search in github and see it used everywhere.